### PR TITLE
Update outdated GRASS GIS module names (g.bands; i.band)

### DIFF
--- a/t.rast.bandcalc/readme
+++ b/t.rast.bandcalc/readme
@@ -16,7 +16,7 @@ e.g. S2_1 and S2_8A
 
  - get the first entry of the output of t.rast.list columns=band_reference
  - get the sensor appreviation split by _
- - get the bands with g.bands pat=<sensor appreviation>
+ - get the bands with i.band.library pat=<sensor appreviation>
  - remove description: split by whitespace
  - find needed bands in formula: if "data[0]" in formula:
  - go through the list of bands and replace (str.replace(old, new) in the formula e.g. data[0] with (input_strds + '.' + bandref[0])

--- a/t.rast.bandcalc/t.rast.bandcalc.html
+++ b/t.rast.bandcalc/t.rast.bandcalc.html
@@ -35,8 +35,8 @@ temporaly related maps overlap in their spatial extent.
 
 <em>
 <a href="t.rast.mapcalc.html">t.rast.mapcalc</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>

--- a/t.rast.filterbands/t.rast.filterbands.html
+++ b/t.rast.filterbands/t.rast.filterbands.html
@@ -11,8 +11,8 @@ This module is a front-end for
 
 <em>
 <a href="t.rast.extract.html">t.rast.extract</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>

--- a/t.rast.filterbands/t.rast.filterbands.py
+++ b/t.rast.filterbands/t.rast.filterbands.py
@@ -95,9 +95,9 @@ def main():
     common_names = dict()
     if sensor_abbr is not None:
         # hard-coded for now, as long as there are no STAC-like common names
-        # in the output of g.bands
+        # in the output of i.band.library
 
-        # from https://github.com/radiantearth/stac-spec/tree/master/extensions/eo#common-band-names
+        # from https://github.com/stac-extensions/eo/#common-band-names
 
         if sensor_abbr == "L5":
             common_names["blue"] = "L5_1"

--- a/t.rast.mask/t.rast.mask.html
+++ b/t.rast.mask/t.rast.mask.html
@@ -24,8 +24,8 @@ temporaly related maps overlap in their spatial extent.
 
 <em>
 <a href="t.rast.algebra.html">t.rast.algebra</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>

--- a/t.rast.ndvi/t.rast.ndvi.html
+++ b/t.rast.ndvi/t.rast.ndvi.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>t.rast.ndvi</em> calculates NDVI from a STRDS. It uses a single 
-STRDS as input and calculates a new STRDS using the red nad nir bands 
+STRDS as input and calculates a new STRDS using the red and nir bands
 included in the input STRDS.
 
 <p>
@@ -31,8 +31,8 @@ temporaly related maps overlap in their spatial extent.
 
 <em>
 <a href="t.rast.mapcalc.html">t.rast.mapcalc</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>

--- a/t.rast.oeapply/t.rast.oeapply.html
+++ b/t.rast.oeapply/t.rast.oeapply.html
@@ -11,8 +11,8 @@ This module is a helper module for the openeo process <em>apply</em>.
 
 <em>
 <a href="t.rast.mapcalc.html">t.rast.mapcalc</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>

--- a/t.rast.renamelabels/t.rast.renamelabels.html
+++ b/t.rast.renamelabels/t.rast.renamelabels.html
@@ -12,8 +12,8 @@ be used outside this context.
 
 <em>
 <a href="t.rast.extract.html">t.rast.extract</a>,
-<a href="g.bands.html">g.bands</a>,
-<a href="i.bands.html">i.bands</a>
+<a href="i.band.library.html">i.band.library</a>,
+<a href="r.semantic.label.html">r.semantic.label</a>
 </em>
 <p>
 <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>


### PR DESCRIPTION
The module names have been renamed from GRASS GIS 7.9.dev to 8.x:
- g.bands -> i.band.library
- i.band -> r.semantic.label

This PR updates the manual pages and some comments in a Python file incl. a STAC reference URL.